### PR TITLE
Fixed changeImage() to apply saved scale

### DIFF
--- a/pygame_functions.py
+++ b/pygame_functions.py
@@ -85,14 +85,15 @@ class newSprite(pygame.sprite.Sprite):
 
     def changeImage(self, index):
         self.currentImage = index
-        if self.angle == 0:
+        if self.angle == 0 and self.scale == 1:
             self.image = self.images[index]
         else:
-            self.image = pygame.transform.rotate(self.images[self.currentImage], -self.angle)
+            self.image = pygame.transform.rotozoom(self.images[self.currentImage], -self.angle, self.scale)
         oldcenter = self.rect.center
         self.rect = self.image.get_rect()
-        self.originalWidth = self.rect.width
-        self.originalHeight = self.rect.height
+        originalRect = self.images[self.currentImage].get_rect()
+        self.originalWidth = originalRect.width
+        self.originalHeight = originalRect.height
         self.rect.center = oldcenter
         self.mask = pygame.mask.from_surface(self.image)
         updateDisplay()


### PR DESCRIPTION
Now each changeSpriteImage() call resets scale of sprite to default value. I believe this patch fixes it, but I'm not sure about originalWidth/originalHeight